### PR TITLE
add host info into PROMPT

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -11,7 +11,14 @@
 
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
 
-PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
+local host_info="%{$fg_bold[magenta]%} "
+if [[ "$USER" != "$DEFAULT_USER" ]]; then
+    host_info+="$USER"
+fi
+if [[ -n "$SSH_CLIENT" ]]; then
+    host_info+="@%m"
+fi
+PROMPT='${host_info} ${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_CLEAN=") %{$fg_bold[green]%}✔ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %{$fg_bold[yellow]%}✗ "

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -11,14 +11,14 @@
 
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
 
-local host_info="%{$fg_bold[magenta]%} "
+local host_info="%{$fg_bold[magenta]%}"
 if [[ "$USER" != "$DEFAULT_USER" ]]; then
     host_info+="$USER"
 fi
 if [[ -n "$SSH_CLIENT" ]]; then
     host_info+="@%m"
 fi
-PROMPT='${host_info} ${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
+PROMPT='${host_info}${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_CLEAN=") %{$fg_bold[green]%}✔ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %{$fg_bold[yellow]%}✗ "

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -84,7 +84,6 @@ dracula_time_segment() {
   fi
 }
 
-local host_info=
 # Context
 # Shows hostname if using SSH or logged in as root
 if [[ -n "${SSH_CONNECTION-}${SSH_CLIENT-}${SSH_TTY-}" ]] || (( EUID == 0 )); then
@@ -92,9 +91,6 @@ if [[ -n "${SSH_CONNECTION-}${SSH_CLIENT-}${SSH_TTY-}" ]] || (( EUID == 0 )); th
 else
   psvar[1]=''
 fi
-
-
-if [[ -n "$SSH_CLIENT" ]]; then
 
 PROMPT="%(?:%{$fg_bold[green]%}${DRACULA_SYMBOL_START}:%{$fg_bold[red]%}${DRACULA_SYMBOL_START})"
 PROMPT+='%{$fg_bold[green]%}$(dracula_time_segment) '


### PR DESCRIPTION
Add user and host information into PROMPT, and they will only shown when `$USER!=$DEFAULT_USER` or in ssh mode.
old:
<img width="663" alt="screen shot 2016-12-11 at 01 09 23" src="https://cloud.githubusercontent.com/assets/3270410/21077306/5289e8ae-bf3f-11e6-9eac-874750c3059a.png">

new:
<img width="517" alt="screen shot 2016-12-11 at 01 08 22" src="https://cloud.githubusercontent.com/assets/3270410/21077303/47f09f64-bf3f-11e6-8a97-41d4d5cdf249.png">