### PR TITLE
Fix git info prompt.

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -16,4 +16,4 @@ PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_inf
 ZSH_THEME_GIT_PROMPT_CLEAN=") %{$fg_bold[green]%}✔ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %{$fg_bold[yellow]%}✗ "
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}("
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX=") %{$reset_color%}"


### PR DESCRIPTION
Fix the way the git prompt is displayed. Currently, there's no closing parenthesis, after branch name:

before:
<img width="205" alt="screen shot 2017-01-13 at 3 14 50 pm" src="https://cloud.githubusercontent.com/assets/51424/21949028/e3e1fb92-d9a3-11e6-97d8-df932e18a905.png">

after:
<img width="218" alt="screen shot 2017-01-13 at 3 14 14 pm" src="https://cloud.githubusercontent.com/assets/51424/21949027/e3e14cc4-d9a3-11e6-98f9-2a92cb12eba7.png">