### PR TITLE
Fix the timestamp by changing %p to %T

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -11,7 +11,7 @@
 
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
 
-PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
+PROMPT='${ret_status}%{$fg_bold[green]%}%T %{$fg_bold[blue]%}%c $(git_prompt_info)% %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_CLEAN=") %{$fg_bold[green]%}✔ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %{$fg_bold[yellow]%}✗ "


### PR DESCRIPTION
I assume the `%p` is taken from http://www.nparikh.org/unix/prompt.php which says it shows `The precise time of  day  in  12-hour  AM/PM format, with seconds.`.

`%p` does not work for me and I could not find any documentation on it.
`man zshmisc` mentions
```
       %T     Current time of day, in 24-hour format.

       %t
       %@     Current time of day, in 12-hour, am/pm format.

       %*     Current time of day in 24-hour format, with seconds.
```

But `%t` and `%@` don't work for me either and I think showing the seconds is unnecessary clutter. Hence I changed it to `%T`.

# Screenshots
## before:
![screenshot_20170516_181912](https://cloud.githubusercontent.com/assets/4498831/26116973/49793fca-3a65-11e7-9912-34eedf7fa709.png)

## after
![screenshot_20170516_182230](https://cloud.githubusercontent.com/assets/4498831/26116992/58dbae62-3a65-11e7-8972-6111ca4f2927.png)
