### PR TITLE
Add Custom Variable Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The status segment indicator (the arrow at the beginning), can be changed by set
 DRACULA_ARROW_ICON="-> "
 ```
 
+### Custom Segment
+The custom segment can be changed by setting the `DRACULA_CUSTOM_VARIABLE` environmental variable.
+```sh
+export DRACULA_CUSTOM_VARIABLE=AWS:PROD:EU-WEST-1
+```
+
 ### Git Locking
 This program automatically makes use of git's `--no-optional-locks` option,
 and it should automatically detect if your version supports the option. However,

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -100,7 +100,9 @@ PROMPT+='%F{blue}%B%c '
 # }}}
 
 # Custom variable {{{
-PROMPT+='%F{green}$DRACULA_CUSTOM_VARIABLE '
+if [[ ! -z $DRACULA_CUSTOM_VARIABLE ]] {
+    PROMPT+='%F{green}$DRACULA_CUSTOM_VARIABLE '
+}
 # }}}
 
 # Async git segment {{{

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -99,6 +99,10 @@ PROMPT+='%F{magenta}%B$(dracula_context)'
 PROMPT+='%F{blue}%B%c '
 # }}}
 
+# Custom variable {{{
+PROMPT+='%F{green}$DRACULA_CUSTOM_VARIABLE '
+# }}}
+
 # Async git segment {{{
 
 dracula_git_status() {


### PR DESCRIPTION
I use scripts to set up my AWS environments - this generic functionality allows users to set a custom environmental variable, which gets displayed in the ZSH Dracula prompt