### PR TITLE
Add Custom Variable Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,44 @@
 All instructions can be found at [draculatheme.com/zsh](https://draculatheme.com/zsh).
 
 ## Configuration
+
 ### Time Segment
+
 The time segment shows a clock in either a 12 or 24 hour format
 based on your locale. To enable it, use the following in your config file:
+
 ```
 DRACULA_DISPLAY_TIME=1
 ```
 
 ### Context Segment
+
 The context segment shows the username, and, if the user is root or logged in via
 SSH, the hostname of the system. To enable this segment, use the following in your config file:
+
 ```
 DRACULA_DISPLAY_CONTEXT=1
 ```
 
 ### Status Segment Indicator
+
 The status segment indicator (the arrow at the beginning), can be changed by setting the `DRACULA_ARROW_ICON` variable. For example, to use an ASCII '->':
+
 ```sh
 DRACULA_ARROW_ICON="-> "
+
+```
+
+### Custom Segment
+
+The custom segment can be changed by setting the `DRACULA_CUSTOM_VARIABLE` environmental variable.
+
+```sh
+export DRACULA_CUSTOM_VARIABLE=AWS:PROD:EU-WEST-1
 ```
 
 ### Git Locking
+
 This program automatically makes use of git's `--no-optional-locks` option,
 and it should automatically detect if your version supports the option. However,
 if, for some reason, the automatically detected values are incorrect, you can
@@ -40,9 +57,9 @@ forcefully disable or enable the functionality by setting the variable
 
 This theme is maintained by the following person(s) and a bunch of [awesome contributors](https://github.com/dracula/zsh/graphs/contributors).
 
-[![Aidan Williams](https://avatars0.githubusercontent.com/u/30708886?s=70)](https://github.com/AGitBoy) |
---- | ---
-[Aidan Williams](https://github.com/AGitBoy) |
+| [![Aidan Williams](https://avatars0.githubusercontent.com/u/30708886?s=70)](https://github.com/AGitBoy) |
+| ------------------------------------------------------------------------------------------------------- |
+| [Aidan Williams](https://github.com/AGitBoy)                                                            |
 
 ## License
 

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -99,6 +99,14 @@ PROMPT+='%F{magenta}%B$(dracula_context)'
 PROMPT+='%F{blue}%B%c '
 # }}}
 
+# Custom variable {{{
+function custom_variable_prompt() {
+  [[ -z $DRACULA_CUSTOM_VARIABLE ]] && return
+  echo "$FG[008]$DRACULA_CUSTOM_VARIABLE "
+}
+PROMPT+='$(custom_variable_prompt)'
+# }}}
+
 # Async git segment {{{
 
 dracula_git_status() {


### PR DESCRIPTION
I use scripts to set up my AWS environments - this generic functionality allows users to set a custom environmental variable, which gets displayed in the ZSH Dracula prompt.