### PR TITLE
Feature/new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The status segment indicator (the arrow at the beginning), can be changed by set
 DRACULA_ARROW_ICON="-> "
 ```
 
+### New Line for commands
+You can display a new line for your commands. So you are able to split the terminal infos and the following command in seperate lines.
+```sh
+DRACULA_DISPLAY_NEW_LINE=1
+```
+
 ### Git Locking
 This program automatically makes use of git's `--no-optional-locks` option,
 and it should automatically detect if your version supports the option. However,

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -16,6 +16,7 @@ source ${0:A:h}/lib/async.zsh
 autoload -Uz add-zsh-hook
 setopt PROMPT_SUBST
 async_init
+PROMPT=''
 # }}}
 
 # Options {{{
@@ -27,6 +28,9 @@ DRACULA_DISPLAY_CONTEXT=${DRACULA_DISPLAY_CONTEXT:-0}
 
 # Changes the arrow icon
 DRACULA_ARROW_ICON=${DRACULA_ARROW_ICON:-➜}
+
+# Set to 1 to use an new line for commands
+DRACULA_DISPLAY_NEW_LINE=${DRACULA_DISPLAY_NEW_LINE:-0}
 
 # function to detect if git has support for --no-optional-locks
 dracula_test_git_optional_lock() {
@@ -59,18 +63,19 @@ DRACULA_GIT_NOLOCK=${DRACULA_GIT_NOLOCK:-$(dracula_test_git_optional_lock)}
 # Status segment {{{
 # arrow is green if last command was successful, red if not, 
 # turns yellow in vi command mode
-PROMPT='%(1V:%F{yellow}:%(?:%F{green}:%F{red}))${DRACULA_ARROW_ICON}'
+if (( ! DRACULA_DISPLAY_NEW_LINE )); then
+    PROMPT+='%(1V:%F{yellow}:%(?:%F{green}:%F{red}))${DRACULA_ARROW_ICON} '
+fi
 # }}}
 
 # Time segment {{{
 dracula_time_segment() {
   if (( DRACULA_DISPLAY_TIME )); then
     if [[ -z "$TIME_FORMAT" ]]; then
-      TIME_FORMAT=" %-H:%M"
-      
+      TIME_FORMAT="%-H:%M"
       # check if locale uses AM and PM
       if ! locale -ck LC_TIME | grep 'am_pm=";"' > /dev/null; then
-        TIME_FORMAT=" %-I:%M%p"
+        TIME_FORMAT="%-I:%M%p"
       fi
     fi
 
@@ -78,7 +83,9 @@ dracula_time_segment() {
   fi
 }
 
-PROMPT+='%F{green}%B$(dracula_time_segment) '
+if [[ -n $(dracula_time_segment) ]]; then
+  PROMPT+='%F{green}%B$(dracula_time_segment) '
+fi
 # }}}
 
 # User context segment {{{
@@ -154,6 +161,13 @@ ZSH_THEME_GIT_PROMPT_CLEAN=") %F{green}%B✔ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %F{yellow}%B✗ "
 ZSH_THEME_GIT_PROMPT_PREFIX="%F{cyan}%B("
 ZSH_THEME_GIT_PROMPT_SUFFIX="%f%b"
+# }}}
+
+# LINEBREAK {{{
+if (( DRACULA_DISPLAY_NEW_LINE)); then
+    PROMPT+=$'\n'
+    PROMPT+='%(1V:%F{yellow}:%(?:%F{green}:%F{red}))${DRACULA_ARROW_ICON} '
+fi
 # }}}
 
 # ensure vi mode is handled by prompt


### PR DESCRIPTION
Hi guys. 
I added a new feature that was requested in the issue #36. I called the feature DRACULA_DISPLAY_NEW_LINE.
Is this activated, the command prompt will write a new line for the user input.

![image](https://user-images.githubusercontent.com/33316737/149588760-5b35741c-ac0b-4c76-9458-cad4a7ba0472.png)

I tested it with all other settings, it works fine for me.

Here a screenshot using tmux showing my .zshrc file and the resulting cli:

![image](https://user-images.githubusercontent.com/33316737/149589052-4c1fe88c-db35-48c6-b6f2-51f35f3bbbd6.png)
