### PR TITLE
Fixed the broken autocomplete

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -79,15 +79,15 @@ fi
 # Status segment {{{
 dracula_arrow() {
 	if [[ "$1" = "start" ]] && (( ! DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "%(1V:%F{yellow}:%(?:%F{green}:%F{red}))${DRACULA_ARROW_ICON} "
+		print -P "$DRACULA_ARROW_ICON "
 	elif [[ "$1" = "end" ]] && (( DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "\n%(1V:%F{yellow}:%(?:%F{green}:%F{red}))${DRACULA_ARROW_ICON} "
+		print -P "\n$DRACULA_ARROW_ICON "
 	fi
 }
 
 # arrow is green if last command was successful, red if not, 
 # turns yellow in vi command mode
-PROMPT+='$(dracula_arrow start)'
+PROMPT+='%(1V:%F{yellow}:%(?:%F{green}:%F{red}))%B$(dracula_arrow start)'
 # }}}
 
 # Time segment {{{
@@ -194,7 +194,7 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%f%b"
 # }}}
 
 # Linebreak {{{
-PROMPT+='$(dracula_arrow end)'
+PROMPT+='%(1V:%F{yellow}:%(?:%F{green}:%F{red}))%B$(dracula_arrow end)'
 # }}}
 
 # define widget without clobbering old definitions


### PR DESCRIPTION
I fixed the autocomplete problem from this 3 issues:
#45 #46 #47 

I moved the color attributes direct into the prompt variable, away form the print command. Same approach like in all other functions.

@avalonwilliams please take a look.

Fixed bug:
Current master branch: ![image](https://user-images.githubusercontent.com/33316737/182014741-1a09fe37-0fa0-4915-8f97-348525b9f569.png)
After my changes: 
![image](https://user-images.githubusercontent.com/33316737/182014707-867ba093-6831-4de9-be2b-5173210f3e34.png)
