### PR TITLE
Moved the space after the arrow icon to be in the arrow variable

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -31,7 +31,7 @@ DRACULA_DISPLAY_TIME=${DRACULA_DISPLAY_TIME:-0}
 DRACULA_DISPLAY_CONTEXT=${DRACULA_DISPLAY_CONTEXT:-0}
 
 # Changes the arrow icon
-DRACULA_ARROW_ICON=${DRACULA_ARROW_ICON:-➜}
+DRACULA_ARROW_ICON=${DRACULA_ARROW_ICON:-➜ }
 
 # Set to 1 to use a new line for commands
 DRACULA_DISPLAY_NEW_LINE=${DRACULA_DISPLAY_NEW_LINE:-0}
@@ -79,9 +79,9 @@ fi
 # Status segment {{{
 dracula_arrow() {
 	if [[ "$1" = "start" ]] && (( ! DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "$DRACULA_ARROW_ICON "
+		print -P "$DRACULA_ARROW_ICON"
 	elif [[ "$1" = "end" ]] && (( DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "\n$DRACULA_ARROW_ICON "
+		print -P "\n$DRACULA_ARROW_ICON"
 	fi
 }
 


### PR DESCRIPTION
I wanted to remove the arrow in my configuration by setting `DRACULA_ARROW_ICON=""`, however, the current behavior always inserts a space between the arrow and the current working directory.

<img width="285" alt="Screenshot 2022-08-11 at 13 41 51" src="https://user-images.githubusercontent.com/7815190/184127439-762ccee0-f228-440f-8faf-23c55a5171b6.png">

I moved the space to be a part of the arrow variable itself rather than within the print function. Now you can do this:

<img width="269" alt="Screenshot 2022-08-11 at 13 43 31" src="https://user-images.githubusercontent.com/7815190/184127848-7c416780-9a46-41f6-be5d-80c3be7521b7.png">

The original behavior is the same. However users will have to update their custom `DRACULA_ARROW_ICON` variable to include a space if they want it.

<img width="277" alt="Screenshot 2022-08-11 at 13 43 58" src="https://user-images.githubusercontent.com/7815190/184128050-d6425ce9-48b9-442c-b430-94587f7e994b.png">

The `README` in fact already matches this

```
### Status Segment Indicator

The status segment indicator (the arrow at the beginning), can be changed by setting the `DRACULA_ARROW_ICON` variable. For example, to use an ASCII '->':

``sh
 DRACULA_ARROW_ICON="-> "

``
```