### PR TITLE
Fix `$DRACULA_ARROW_ICON` getting parsed as a command-line flag to `print`

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -79,9 +79,9 @@ fi
 # Status segment {{{
 dracula_arrow() {
 	if [[ "$1" = "start" ]] && (( ! DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "$DRACULA_ARROW_ICON"
+		print -P -- "$DRACULA_ARROW_ICON"
 	elif [[ "$1" = "end" ]] && (( DRACULA_DISPLAY_NEW_LINE )); then
-		print -P "\n$DRACULA_ARROW_ICON"
+		print -P -- "\n$DRACULA_ARROW_ICON"
 	fi
 }
 


### PR DESCRIPTION
When `$DRACULA_ARROW_ICON` begins with an unescaped `-` character, it will be read as a command line flag by the `print` command. This causes the error `dracula_arrow:print:2: bad option: -> ` (for example) to get outputted on each new prompt line. This PR passes the `--` flag to `print` before passing `$DRACULA_ARROW_ICON` to ensure that `print` does not attempt to parse the arrow icon as a command-line flag.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.
>
> **Before**:
> <img width="774" alt="Screenshot 2023-05-31 at 9 24 18 AM" src="https://github.com/dracula/zsh/assets/44714422/8559809a-7401-4056-8c4e-80b3f0a0b986">
> **After**:
> <img width="845" alt="Screenshot 2023-05-31 at 9 24 47 AM" src="https://github.com/dracula/zsh/assets/44714422/613c3f19-a13d-4f62-b438-19b675dabcea">

*Note*: the literal string value of `$DRACULA_ARROW_ICON` in this context is `-> `, I'm using a font with ligatures that merges those two first characters into one symbol.