### PR TITLE
Fix install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,25 +2,19 @@
 
 #### Install using Git
 
-If you are a git user, you can install the theme and keep up to date by cloning the repo:
+If you are a git user, you can install the theme and keep up to date by cloning the repo into your oh-mu-zsh directory:
 
-    git clone https://github.com/dracula/zsh.git
-
-And creating a symbolic link to [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/)'s theme folder:
-
-    ln -s $DRACULA_THEME/dracula.zsh-theme $OH_MY_ZSH/themes/dracula.zsh-theme
-
-_P.S.: Remember that you should replace `$DRACULA_THEME` and `$OH_MY_ZSH` with the actual directories for this command to work._
+    cd $ZSH_CUSTOM/themes
+    git clone https://github.com/dracula/zsh.git dracula
 
 #### Install manually
 
-1.  Download using the [GitHub .zip download](https://github.com/dracula/zsh/archive/master.zip) option and unzip them.
-2.  Move `dracula.zsh-theme` file to [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/)'s theme folder: `oh-my-zsh/themes/dracula.zsh-theme`.
-3.  Move `/lib` to [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/)'s theme folder: `oh-my-zsh/themes/lib`.
+1.  Download using the [GitHub .zip download](https://github.com/dracula/zsh/archive/master.zip) option and unzip them into a folder named `dracula`.
+2.  Move the `dracula` folder into [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/)'s theme folder: `oh-my-zsh/themes/dracula`.
 
 #### Activating theme
 
-Go to your `~/.zshrc` file and set `ZSH_THEME="dracula"`.
+Go to your `~/.zshrc` file and set `ZSH_THEME="dracula/dracula"`.
 
 #### Install using [zplug](https://github.com/zplug/zplug)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 #### Install using Git
 
-If you are a git user, you can install the theme and keep up to date by cloning the repo into your oh-mu-zsh directory:
+If you are a git user, you can install the theme and keep up to date by cloning the repo into your oh-my-zsh directory:
 
     cd $ZSH_CUSTOM/themes
     git clone https://github.com/dracula/zsh.git dracula


### PR DESCRIPTION
As per the discussion and solutions provided around here:
https://github.com/dracula/zsh/issues/11#issuecomment-1429361016

The instructions for manual install and git install as they are on https://draculatheme.com/zsh right now don't work for me and other users. This git install method works and is confirmed by multiple users. The instructions for the non-git install should have the same result, except for the missing `.git` folder.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.