### PR TITLE
Match up style for Git prompt characters

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -187,7 +187,7 @@ add-zsh-hook precmd dracula_git_async
 
 PROMPT+='$DRACULA_GIT_STATUS'
 
-ZSH_THEME_GIT_PROMPT_CLEAN=") %F{green}%B✔ "
+ZSH_THEME_GIT_PROMPT_CLEAN=") %F{green}%B✓ "
 ZSH_THEME_GIT_PROMPT_DIRTY=") %F{yellow}%B✗ "
 ZSH_THEME_GIT_PROMPT_PREFIX="%F{cyan}%B("
 ZSH_THEME_GIT_PROMPT_SUFFIX="%f%b"


### PR DESCRIPTION
Replaces "✔" (heavy check mark) with "✓" (check mark) to match up with "" (✗) ([not-heavy] ballot x) character used for Git prompt.