### PR TITLE
changed source path for lib/async

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -13,7 +13,7 @@
 # @maintainer Avalon Williams <avalonwilliams@protonmail.com>
 
 # Initialization {{{
-source ${0:A:h}/lib/async.zsh
+source ${ZSH_CUSTOM}/themes/lib/async.zsh
 autoload -Uz add-zsh-hook
 setopt PROMPT_SUBST
 async_init


### PR DESCRIPTION
Fixes https://github.com/dracula/zsh/issues/60

This fixes my nixOS case. 

My thinking is that  `${ZSH_CUSTOM}/themes` is a bit more idiomatic for oh my zsh. 

See [oh-my-zsh wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Customization)


ZSH_CUSTOM should always be set. 


The downside is that that's being set by oh-my-zsh, and not ZSH itself. 