### PR TITLE
Use builtin cd

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -139,7 +139,7 @@ PROMPT+='$(custom_variable_prompt)'
 
 dracula_git_status() {
 	(( ! DRACULA_DISPLAY_GIT )) && return
-	cd "$1"
+	builtin cd "$1"
 	
 	local ref branch lockflag
 	


### PR DESCRIPTION
Calling `cd` directly has the risk of calling an alias or function which the user may have defined over the builtin `cd`. For example, my own RC files have the following:

```sh
cd() { builtin cd "$@" && printf "\033c" && ll; }
```

In my particular case, my `ls` output was appearing in my prompt when using this theme.

Instead calling `builtin cd` guarantees that the builtin version is called despite name clashes with user-defined functions/aliases.