### PR TITLE
Adding a DIR TRIM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ path, use the following in your config file:
 DRACULA_DISPLAY_FULL_CWD=1
 ```
 
+### Limit Number of Displayed Directories In Prompt
+
+If you are using the [DRACULA_DISPLAY_FULL_CWD](#directory-segment) to display the full path in your prompt, you can use
+this setting to limit the number of directories that get displayed in the path. Default is 0 which displays the full path.
+
+```sh
+DRACULA_DIR_TRIM=2
+```
+
+#### Examples
+
+DRACULA_DIR_TRIM=0
+
+```sh
+➜ username ~/level1/level2/level3/level4
+```
+
+DRACULA_DIR_TRIM=2
+
+```sh
+➜ username level3/level4
+```
+
 ### Status Segment Indicator
 
 The status segment indicator (the arrow at the beginning), can be changed by setting the `DRACULA_ARROW_ICON` variable. For example, to use an ASCII '->':

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ DRACULA_DISPLAY_FULL_CWD=1
 
 ### Limit Number of Displayed Directories In Prompt
 
-If you are using the [DRACULA_DISPLAY_FULL_CWD](#directory-segment) to display the full path in your prompt, you can use
+If you are using the [DRACULA_DISPLAY_FULL_CWD](#directory-segment) setting to display the full path in your prompt, you can use
 this setting to limit the number of directories that get displayed in the path. Default is 0 which displays the full path.
 
 ```sh

--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -39,6 +39,9 @@ DRACULA_DISPLAY_NEW_LINE=${DRACULA_DISPLAY_NEW_LINE:-0}
 # Set to 1 to show full path of current working directory
 DRACULA_DISPLAY_FULL_CWD=${DRACULA_DISPLAY_FULL_CWD:-0}
 
+# Set to 1 or greater in order to show that many directories in your path prompt
+DRACULA_DIR_TRIM=${DRACULA_DIR_TRIM:-0}
+
 # function to detect if git has support for --no-optional-locks
 dracula_test_git_optional_lock() {
 	local git_version=${DEBUG_OVERRIDE_V:-"$(git version | cut -d' ' -f3)"}
@@ -117,7 +120,7 @@ PROMPT+='%F{magenta}%B$(dracula_context)'
 # Directory segment {{{
 dracula_directory() {
 	if (( DRACULA_DISPLAY_FULL_CWD )); then
-		print -P '%~ '
+		print -P '%${DRACULA_DIR_TRIM}~ '
 	else
 		print -P '%c '
 	fi


### PR DESCRIPTION
Hi! I started using this dracula theme for zsh and really love it. I noticed that the default of the theme is to only display the directory that I am in within the path. I normally prefer to have my prompt show the last 2 directories in my current working directory path and that is accomplished in zsh by just adding a number in the `%~` prompt. I normally do `%2~` for example. I made these modifications and am sharing this PR in case you would like to merge it in as a new feature.

Some document that might explain what I am talking about much better:
https://www.baeldung.com/linux/shorten-directory-path-command-line#zsh-prompt-current-working-directory
