### PR TITLE
Fix loading lib/async.zsh from script dir

### DIFF
--- a/dracula.zsh-theme
+++ b/dracula.zsh-theme
@@ -17,7 +17,7 @@ dracula_source_async() {
 	local -a candidate_paths
 	local path
 	candidate_paths=(
-		"${0:A:h}/lib/async.zsh"
+		"${${(%):-%x}:A:h}/lib/async.zsh"
 		"${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/dracula/lib/async.zsh"
 		"${ZSH:-$HOME/.oh-my-zsh}/themes/dracula/lib/async.zsh"
 	)


### PR DESCRIPTION
Replaced `$0` with `${(%):-%x}` to get current script name inside a function.

Related to https://github.com/dracula/zsh/issues/60#issuecomment-4301578827.